### PR TITLE
Add locktime param to BitcoinTransactionBuilder

### DIFF
--- a/lib/src/transaction_builder/transaction_builder.dart
+++ b/lib/src/transaction_builder/transaction_builder.dart
@@ -35,6 +35,7 @@ class BitcoinTransactionBuilder implements BasedBitcoinTransacationBuilder {
   final bool isFakeTransaction;
   final BitcoinOrdering inputOrdering;
   final BitcoinOrdering outputOrdering;
+  final List<int> locktime;
   BitcoinTransactionBuilder({
     required this.outPuts,
     required this.fee,
@@ -45,6 +46,7 @@ class BitcoinTransactionBuilder implements BasedBitcoinTransacationBuilder {
     this.memo,
     this.enableRBF = false,
     this.isFakeTransaction = false,
+    this.locktime = BitcoinOpCodeConst.defaultTxLocktime,
   }) : utxosInfo = utxos {
     _validateBuilder();
   }
@@ -490,7 +492,7 @@ that demonstrate the right to spend the bitcoins associated with the correspondi
 
     /// create new transaction with inputs and outputs and isSegwit transaction or not
     BtcTransaction transaction =
-        BtcTransaction(inputs: inputs, outputs: outputs);
+        BtcTransaction(inputs: inputs, outputs: outputs, locktime: locktime);
 
     /// we define empty witnesses. maybe the transaction is segwit and We need this
     final witnesses = <TxWitnessInput>[];
@@ -653,7 +655,7 @@ that demonstrate the right to spend the bitcoins associated with the correspondi
 
     /// create new transaction with inputs and outputs and isSegwit transaction or not
     BtcTransaction transaction =
-        BtcTransaction(inputs: inputs, outputs: outputs);
+        BtcTransaction(inputs: inputs, outputs: outputs, locktime: locktime);
 
     /// we define empty witnesses. maybe the transaction is segwit and We need this
     final witnesses = <TxWitnessInput>[];

--- a/test/transaction_builder_locktime_test.dart
+++ b/test/transaction_builder_locktime_test.dart
@@ -1,0 +1,28 @@
+import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BitcoinTransactionBuilder locktime', () {
+    test('defaults to defaultTxLocktime', () {
+      final b = BitcoinTransactionBuilder(
+        outPuts: const [],
+        fee: BigInt.zero,
+        network: BitcoinNetwork.mainnet,
+        utxos: const [],
+      );
+      expect(b.locktime, BitcoinOpCodeConst.defaultTxLocktime);
+    });
+
+    test('stores the provided locktime', () {
+      final lt = [0x50, 0x01, 0xcf, 0x00];
+      final b = BitcoinTransactionBuilder(
+        outPuts: const [],
+        fee: BigInt.zero,
+        network: BitcoinNetwork.mainnet,
+        utxos: const [],
+        locktime: lt,
+      );
+      expect(b.locktime, lt);
+    });
+  });
+}


### PR DESCRIPTION
adds an optional locktime (defaults to defaultTxLocktime), threaded into the built BtcTransaction in both build paths. 

ref: https://github.com/payjoin/rust-payjoin/issues/1676